### PR TITLE
Improve check for intersecting intervals

### DIFF
--- a/custom_components/yasno_outages/api.py
+++ b/custom_components/yasno_outages/api.py
@@ -118,6 +118,8 @@ class YasnoOutagesApi:
                     if (
                         start_date <= event_start <= end_date
                         or start_date <= event_end <= end_date
+                        # Include events that intersect beyond the timeframe
+                        # See: https://github.com/denysdovhan/ha-yasno-outages/issues/14
                         or event_start <= start_date <= event_end
                         or event_start <= end_date <= event_end
                     ):

--- a/custom_components/yasno_outages/api.py
+++ b/custom_components/yasno_outages/api.py
@@ -118,6 +118,8 @@ class YasnoOutagesApi:
                     if (
                         start_date <= event_start <= end_date
                         or start_date <= event_end <= end_date
+                        or event_start <= start_date <= event_end
+                        or event_start <= end_date <= event_end
                     ):
                         events.append(
                             {


### PR DESCRIPTION
Handle the case when [start_date, end_date] lies entirely within [event_start, event_end], for example:

start_date = 1:00
end_date = 2:00
event_start = 0:00
event_end = 4:00

Ref: https://github.com/denysdovhan/ha-yasno-outages/pull/15#issuecomment-2250769033