### PR TITLE
fix: wrong url for selecting group

### DIFF
--- a/custom_components/yasno_outages/translations/en.json
+++ b/custom_components/yasno_outages/translations/en.json
@@ -20,7 +20,7 @@
           "group": "Please select your group:"
         },
         "data_description": {
-          "group": "You can find your group at: https://app.yasno.ua"
+          "group": "You can find your group at: https://static.yasno.ua/kyiv/outages"
         }
       }
     }
@@ -45,7 +45,7 @@
           "group": "Please select your group:"
         },
         "data_description": {
-          "group": "You can find your group at: https://app.yasno.ua"
+          "group": "You can find your group at: https://static.yasno.ua/kyiv/outages"
         }
       }
     }

--- a/custom_components/yasno_outages/translations/uk.json
+++ b/custom_components/yasno_outages/translations/uk.json
@@ -20,7 +20,7 @@
           "group": "Оберіть свою групу:"
         },
         "data_description": {
-          "group": "Знайдіть свою групу на: https://app.yasno.ua"
+          "group": "Знайдіть свою групу на: https://static.yasno.ua/kyiv/outages"
         }
       }
     }
@@ -45,7 +45,7 @@
           "group": "Оберіть свою групу:"
         },
         "data_description": {
-          "group": "Знайдіть свою групу на: https://app.yasno.ua"
+          "group": "Знайдіть свою групу на: https://static.yasno.ua/kyiv/outages"
         }
       }
     }


### PR DESCRIPTION
Fix wrong url:

`app.yasno.ua` returns 404.
`static.yasno.ua/kyiv/outages` returns proper app. There is no index route for this page.