### PR TITLE
fix(coordinator): return outage end time in next_connectivity instead of start time

### DIFF
--- a/custom_components/yasno_outages/coordinator.py
+++ b/custom_components/yasno_outages/coordinator.py
@@ -400,7 +400,7 @@ class YasnoOutagesCoordinator(DataUpdateCoordinator):
         # Find next outage
         if event := find_next_outage(events, now):
             LOGGER.debug("Next connectivity event: %s", event)
-            return event.start
+            return event.end
 
         return None
 


### PR DESCRIPTION
When not currently in an outage, next_connectivity was incorrectly
returning the start time of the next outage (event.start) instead of
the end time (event.end). This caused next_connectivity to match
next_planned_outage, which is incorrect behavior.

The sensor should return when connectivity will be restored:
- If currently in outage: return end time of current outage
- If not in outage: return end time of next outage

Fixes #103
