### PR TITLE
[codex] update release-drafter workflow for v7

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,7 +18,7 @@ categories:
       - fix
       - bug
   - title: 🧰 Maintenance
-    label:
+    labels:
       - chore
       - dependencies
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     steps:
       - name: 📝 Draft Release
         id: release_drafter
-        uses: release-drafter/release-drafter@v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: release-drafter/release-drafter@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This updates the release drafting flow for `release-drafter/release-drafter@v7`.

The issue is that the existing workflow still uses the v6 action contract and relies on the `GITHUB_TOKEN` environment variable. Release Drafter v7 switched to the `token` action input and also validates configuration more strictly. If we merged the version bump alone, release drafting could fail or behave inconsistently after the upgrade.

The root cause is that the current repository setup was written for the older action API and also contains a maintenance category entry using `label` instead of `labels`. While older versions tolerated that shape, v7 explicitly tightened configuration parsing and schema validation.

The fix updates the workflow to call `release-drafter/release-drafter@v7` with `with.token`, and normalizes the release drafter config so the maintenance category uses `labels`. That keeps the repository aligned with the new action contract and avoids config validation issues when the draft release job runs on `main`.

## Validation

I validated the change with the repository scripts required by the project:

- `scripts/lint`
- `scripts/test`
